### PR TITLE
Add a check for powerlog path variable

### DIFF
--- a/powerlog_run.sh
+++ b/powerlog_run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-PL="/Applications/Intel\ Power\ Gadget/PowerLog"
-eval "$PL" -file temp.csv -cmd $1
+if [ -z "${FERNIVY_POWERLOG_PATH}" ]; then
+	FERNIVY_POWERLOG_PATH="/Applications/Intel\ Power\ Gadget/PowerLog"
+fi
+
+eval "$FERNIVY_POWERLOG_PATH" -file temp.csv -cmd $1


### PR DESCRIPTION
Fixes #6 

User can set an environment variable with a path to PowerLog like this:

`export FERNIVY_POWERLOG_PATH=<path>`

where the path should be in quotation marks. This path will be then taken to run PowerLog.

If this environment variable isn't defined, the default installation path will be used.