### PR TITLE
Update paths for scripts when using homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv/
 output_*.csv
 
 **/package/
+**/package-brew/
 
 *.dsc
 *.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [v1.2.0] 1 April 2022
+- Added `package-brew` generator for PowerLog (works with `homebrew` packaging)
 - Edited the README to contains up-to-date information
 - Created the CONTRIBUTING.md
 - Created the CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ powerlog: clean_powerlog
 	@chmod +x powerlog/package/fernivy
 	@chmod +x powerlog/package/powerlog_run.sh
 
+brew_powerlog: clean_powerlog
+	@python3 generate.py brew_powerlog
+	@chmod +x powerlog/package/fernivy
+	@chmod +x powerlog/package/powerlog_run.sh
+
 clean_powerlog:
 	@rm -rf powerlog/package
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,11 @@ powerlog: clean_powerlog
 	@python3 generate.py powerlog
 	@chmod +x powerlog/package/fernivy
 	@chmod +x powerlog/package/powerlog_run.sh
-
-brew_powerlog: clean_powerlog
-	@python3 generate.py brew_powerlog
-	@chmod +x powerlog/package/fernivy
-	@chmod +x powerlog/package/powerlog_run.sh
+	@chmod +x powerlog/package-brew/fernivy
+	@chmod +x powerlog/package-brew/powerlog_run.sh
 
 clean_powerlog:
 	@rm -rf powerlog/package
+	@rm -rf powerlog/package-brew
 
 clean: clean_perf clean_powerlog

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 package: fernivy
 maintainer: FernIvy
-version: 1.1.0
+version: 1.2.0
 python: python3
 website: https://fernivy.github.io/docs/
 description: A uniform tool for measuring energy consumption 

--- a/generate.py
+++ b/generate.py
@@ -77,15 +77,28 @@ def generate_perf(conf):
     shutil.copyfile("parser.py", "perf/package/parser.py")
 
 
-def generate_powerlog():
+def generate_powerlog(conf=None):
     """
     This generator creates the package for powerlog.
     """
     shutil.copytree("powerlog/backup/", "powerlog/package/")
-    generate_fernivy("powerlog",
-        lambda line :
-            line.replace("$TOOL\"/backup/\"$TOOL\"_run.sh\"", "./powerlog_run.sh")
-    )
+    if conf is None: # installed from source
+        generate_fernivy("powerlog",
+            lambda line :
+                line.replace("$TOOL\"/backup/\"$TOOL\"_run.sh\"", "./powerlog_run.sh")
+        )
+    else: # installed through homebrew
+        generate_fernivy("powerlog",
+            lambda line :
+                line.replace(
+                    "$TOOL\"/backup/\"$TOOL\"_run.sh\"",
+                    f"\"/usr/local/Cellar/fernivy/{conf.configs['version']}/bin/powerlog_run.sh"
+                )
+                .replace(
+                    "parser.py",
+                    f"/usr/local/Cellar/fernivy/{conf.configs['version']}/bin/parser.py"
+                )
+        )
     shutil.copyfile("parser.py", "powerlog/package/parser.py")
 
 
@@ -97,3 +110,5 @@ if __name__ == "__main__":
         generate_perf(config)
     elif sys.argv[1] == "powerlog":
         generate_powerlog()
+    elif sys.argv[1] == "brew_powerlog":
+        generate_powerlog(config)

--- a/generate.py
+++ b/generate.py
@@ -87,10 +87,7 @@ def generate_powerlog(conf):
     # installation from source
     generate_fernivy("powerlog",
                      lambda line:
-                     line.replace(
-                         "$TOOL\"/backup/\"$TOOL\"_run.sh\"",
-                         "./powerlog/package/powerlog_run.sh")
-                     .replace("parser.py", "./powerlog/package/parser.py")
+                     line.replace("$TOOL\"/backup/\"$TOOL\"_run.sh\"", "./powerlog_run.sh")
                      )
     # installation through homebrew
     generate_fernivy("powerlog",

--- a/generate.py
+++ b/generate.py
@@ -1,5 +1,6 @@
 import sys, shutil
 
+
 class Config:
     """
     The class which deals with the configurations of the project.
@@ -9,15 +10,15 @@ class Config:
         self._configs = {}
         with open(filename) as f:
             for line in f:
-               data = line.strip().split(": ")
-               self._configs[data[0]] = data[1]
+                data = line.strip().split(": ")
+                self._configs[data[0]] = data[1]
 
     @property
     def configs(self):
         return self._configs
 
 
-def generate_fernivy(tool, replace):
+def generate_fernivy(tool, replace, package="package"):
     """
     This generator:
     * skips the line assigning the TOOL variable,
@@ -27,7 +28,7 @@ def generate_fernivy(tool, replace):
     # input file
     fin = open("template.sh", "rt")
     # output file to write the result to
-    fout = open(tool + "/package/fernivy", "wt")
+    fout = open(tool + f"/{package}/fernivy", "wt")
     # for each line in the input file
     for line in fin:
         if line.startswith("TOOL="):
@@ -65,41 +66,47 @@ def generate_perf(conf):
     """
     shutil.copytree("perf/backup/", "perf/package/")
     generate_fernivy("perf",
-        lambda line :
-            line.replace(
-                    "# Request for sudo access when needed",
-                    "if (( $EUID != 0 )); then echo \"Please run as root!\"; exit; fi"
-                )
-                .replace("$TOOL\"/backup/\"$TOOL\"_run.sh\"", "/usr/lib/perf_run.sh")
-                .replace("parser.py", "/usr/lib/parser.py")
-    )
+                     lambda line:
+                     line.replace(
+                         "# Request for sudo access when needed",
+                         "if (( $EUID != 0 )); then echo \"Please run as root!\"; exit; fi"
+                     )
+                     .replace("$TOOL\"/backup/\"$TOOL\"_run.sh\"", "/usr/lib/perf_run.sh")
+                     .replace("parser.py", "/usr/lib/parser.py")
+                     )
     generate_perf_control(conf)
     shutil.copyfile("parser.py", "perf/package/parser.py")
 
 
-def generate_powerlog(conf=None):
+def generate_powerlog(conf):
     """
-    This generator creates the package for powerlog.
+    This generator creates the package and package-brew for powerlog.
     """
     shutil.copytree("powerlog/backup/", "powerlog/package/")
-    if conf is None: # installed from source
-        generate_fernivy("powerlog",
-            lambda line :
-                line.replace("$TOOL\"/backup/\"$TOOL\"_run.sh\"", "./powerlog_run.sh")
-        )
-    else: # installed through homebrew
-        generate_fernivy("powerlog",
-            lambda line :
-                line.replace(
-                    "$TOOL\"/backup/\"$TOOL\"_run.sh\"",
-                    f"\"/usr/local/Cellar/fernivy/{conf.configs['version']}/bin/powerlog_run.sh"
-                )
-                .replace(
-                    "parser.py",
-                    f"/usr/local/Cellar/fernivy/{conf.configs['version']}/bin/parser.py"
-                )
-        )
+    shutil.copytree("powerlog/backup/", "powerlog/package-brew/")
+    # installation from source
+    generate_fernivy("powerlog",
+                     lambda line:
+                     line.replace(
+                         "$TOOL\"/backup/\"$TOOL\"_run.sh\"",
+                         "./powerlog/package/powerlog_run.sh")
+                     .replace("parser.py", "./powerlog/package/parser.py")
+                     )
+    # installation through homebrew
+    generate_fernivy("powerlog",
+                     lambda line:
+                     line.replace(
+                         "$TOOL\"/backup/\"$TOOL\"_run.sh\"",
+                         f"/usr/local/Cellar/fernivy/{conf.configs['version']}/bin/powerlog_run.sh"
+                     )
+                     .replace(
+                         "parser.py",
+                         f"/usr/local/Cellar/fernivy/{conf.configs['version']}/bin/parser.py"
+                     ),
+                     package="package-brew"
+                     )
     shutil.copyfile("parser.py", "powerlog/package/parser.py")
+    shutil.copyfile("parser.py", "powerlog/package-brew/parser.py")
 
 
 if __name__ == "__main__":
@@ -109,6 +116,4 @@ if __name__ == "__main__":
     if sys.argv[1] == "perf":
         generate_perf(config)
     elif sys.argv[1] == "powerlog":
-        generate_powerlog()
-    elif sys.argv[1] == "brew_powerlog":
         generate_powerlog(config)


### PR DESCRIPTION
This PR implements the following changes:

_Insert list of changes here_
- Adds a homebrew powerlog generate method that puts in the correct paths

_Remove the ones that are not applicable:_
* [x] I have added the necessary changes to `generate.py`.
* [x] I have added the necessary changes to `Makefile`.
* [x] I have checked that the generated tools work on my OS.
* [x] I followed the code style conventions. 

