### PR TITLE
Remove sleep time when only run once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fixed the generator to not copy the `debian` folder to `perf/package/`
+- Remove sleep time after the final run
 
 ## [v1.2.0] 1 April 2022
 - Added `package-brew` generator for PowerLog (works with `homebrew` packaging)

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 package: fernivy
 maintainer: FernIvy
-version: 1.2.0
+version: 1.2.1
 python: python3
 website: https://fernivy.github.io/docs/
 description: A uniform tool for measuring energy consumption 

--- a/template.sh
+++ b/template.sh
@@ -19,7 +19,6 @@ loading_bar(){
     if [ $2 -lt $1 ]; then
         # if it is not the last iteration, overwrite previous bar
         echo -ne "$STRING\r"
-        sleep $SLP
     else
         echo "$STRING"
     fi
@@ -183,7 +182,11 @@ for (( i=0; i<RUNS; i++ )); do
 
     echo $F >> $TMP # add the name of the file to the TMP file
 
-	  loading_bar $RUNS $(($i+1)) # update the loading bar
+    loading_bar $RUNS $(($i+1)) # update the loading bar
+
+    if [[ $i -lt $(($RUNS-1)) ]]; then
+        sleep $SLP
+    fi
 done
 
 # call the parser


### PR DESCRIPTION
This PR implements the following changes:

* Removes the sleep time from the loading bar function
* Adds the sleep time to the main loop and executes it only between runs, not after the last one

_Remove the ones that are not applicable:_
* [X] I have checked that the generated tools work on my OS.
* [X] I followed the code style conventions. 

